### PR TITLE
1.71 Fix for attacks being marked deleted

### DIFF
--- a/src/PFAttacks.js
+++ b/src/PFAttacks.js
@@ -525,10 +525,14 @@ export function updateAssociatedAttacksFromParents(callback){
 		});
 		attrs = _.flatten(attrs);
 		getAttrs(attrs,function(v){
+			ids=ids.map(function(id){return id.toLowerCase();});
 			getSectionIDs('repeating_spells',function(spellIDs){
+				spellIDs = _.map(spellIDs,function(id){return id.toLowerCase();});
 				getSectionIDs('repeating_item',function(itemIDs){
+					itemIDs = _.map(itemIDs,function(id){return id.toLowerCase();});
 					getSectionIDs('repeating_ability',function(abilityIDs){
 						var setter={};
+						abilityIDs = _.map(abilityIDs,function(id){return id.toLowerCase();});
 						TAS.debug("################","Checking linked attacks. attack links, spellids, itemids, abilityids",v,spellIDs,itemIDs,abilityIDs);
 						_.each(ids,function(id){
 							if(v['repeating_weapon_'+id+'_source-item']) {
@@ -538,8 +542,8 @@ export function updateAssociatedAttacksFromParents(callback){
 									if( _.size(itemIDs>0) && _.contains(itemIDs,v['repeating_weapon_'+id+'_source-item'])){
 										PFInventory.createAttackEntryFromRow(v['repeating_weapon_'+id+'_source-item'],doneOne,true,null,id);
 									} else {
-										TAS.debug("weapon "+id+" item link is not found:"+v['repeating_weapon_'+id+'_source-item']);
-										setter['repeating_weapon_'+id+'_source-item']='DELETED';
+										TAS.warn("weapon "+id+" item link is not found:"+v['repeating_weapon_'+id+'_source-item']);
+										//setter['repeating_weapon_'+id+'_source-item']='DELETED';
 									}
 								}
 							} else if (v['repeating_weapon_'+id+'_source-spell']) {
@@ -549,8 +553,8 @@ export function updateAssociatedAttacksFromParents(callback){
 									if(_.size(spellIDs>0) && _.contains(spellIDs,v['repeating_weapon_'+id+'_source-spell'])){
 										PFSpells.createAttackEntryFromRow(v['repeating_weapon_'+id+'_source-spell'],doneOne,true,null,id);
 									} else {
-										TAS.debug("weapon "+id+" spell link is not found:"+v['repeating_weapon_'+id+'_source-spell']);
-										setter['repeating_weapon_'+id+'_source-spell']='DELETED';
+										TAS.warn("weapon "+id+" spell link is not found:"+v['repeating_weapon_'+id+'_source-spell']);
+										//setter['repeating_weapon_'+id+'_source-spell']='DELETED';
 									}
 								}
 							} else if (v['repeating_weapon_'+id+'_source-ability']) {
@@ -560,8 +564,8 @@ export function updateAssociatedAttacksFromParents(callback){
 									if(_.size(abilityIDs>0) && _.contains(abilityIDs,v['repeating_weapon_'+id+'_source-ability'])){
 										PFAbility.createAttackEntryFromRow(v['repeating_weapon_'+id+'_source-ability'],doneOne,true,null,id);
 									} else {
-										TAS.debug("weapon "+id+" ability link is not found:"+v['repeating_weapon_'+id+'_source-ability']);
-										setter['repeating_weapon_'+id+'_source-ability']='DELETED';
+										TAS.warn("weapon "+id+" ability link is not found:"+v['repeating_weapon_'+id+'_source-ability']);
+										//setter['repeating_weapon_'+id+'_source-ability']='DELETED';
 									}
 								}
 							} else {

--- a/src/PFConst.js
+++ b/src/PFConst.js
@@ -1,6 +1,6 @@
 export default {
 	/* Pathfinder SHEET constants */
-	version: 1.7,
+	version: 1.71,
 	announcementVersionAttr: 'attentionv170-show',
 
 	/***************************************Lists of Fields ************************************************************/

--- a/src/index.html
+++ b/src/index.html
@@ -13796,7 +13796,7 @@
 					{{#duration}}<div class="sheet-roll-row"><div class="sheet-roll-cell">**<span data-i18n="duration">Duration</span>:**&nbsp;{{duration}}</div></div>{{/duration}}
 					{{#sr}}<div class="sheet-roll-row"><div class="sheet-roll-cell">**<span data-i18n="spell-resistance">Spell Resistance</span>:**&nbsp;{{sr}}</div></div>{{/sr}}
 				</div>
-				<div style="display:table;width:100%;">
+				<div class="sheet-roll-table-inner">
 					<div class="sheet-roll-group2">
 						{{#saving_throw}}<div class="sheet-roll-row">
 							<div class="sheet-roll-cell">**<span data-i18n="save-effect">Save</span>:**&nbsp;{{saving_throw}}</div>
@@ -14109,7 +14109,7 @@
 					</span>
 					{{#subtitle}}<span class="sheet-subtitle">{{subtitle}}</span>{{/subtitle}}
 				</div>
-				<div style="display:table;width:100%;">
+				<div class="sheet-roll-table-inner">
 					<div class="sheet-roll-groupi">
 						{{^no_attack_roll}}{{#attack}}<div class="sheet-roll-row"><div class="sheet-roll-cell sheet-atk">**{{^attack1name}}<span data-i18n="attack">Attack</span>{{/attack1name}}{{#attack1name}}{{attack1name}}{{/attack1name}}**</div><div class="sheet-roll-cell sheet-left">{{attack}}{{^vsother}}{{#vs}}&nbsp;{{#vsac}}<span class="sheet-vs" data-i18n="versus-armor-class">vs AC</span>{{/vsac}}{{#vstouch}}<span class="sheet-vs" data-i18n="versus-touch">vs Touch</span>{{/vstouch}}{{#vsff}}<span class="sheet-vs" data-i18n="versus-flat-footed">vs FF</span>{{/vsff}}{{#vsfft}}<span class="sheet-vs" data-i18n="versus-flat-footed-touch">vs FF Touch</span>{{/vsfft}}{{#vscmd}}<span class="sheet-vs" data-i18n="versus-combat-maneuver-defense">vs CMD</span>{{/vscmd}}{{#vscmb}}<span class="sheet-vs" data-i18n="versus-combat-maneuver-bonus">vs CMB</span>{{/vscmb}}{{/vs}}{{/vsother}}</div></div>{{/attack}}{{/no_attack_roll}}
 						{{^no_damage}}{{#damage}}<div class="sheet-roll-row"><div class="sheet-roll-cell sheet-dmg">**<span data-i18n="damage">Damage</span>**</div><div class="sheet-roll-cell">{{^attack}}+{{/attack}}{{damage}}</div></div>{{/damage}}{{/no_damage}}
@@ -14248,7 +14248,7 @@
 					<div class="sheet-roll-row"><div class="sheet-roll-cell sheet-atk" data-i18n-title="dual_precision-abbrv" data-i18n-aria-label="dual_precision-abbrv">{{#dual_precision_dmg_type}}**{{dual_precision_dmg_type}}**{{/dual_precision_dmg_type}}{{^dual_precision_dmg_type}}**<span data-i18n="dual_precision-abbrv">Extra Dmg</span>**{{/dual_precision_dmg_type}}</div><div class="sheet-roll-cell">{{dual_precision_dmg}}</div></div>
 					</div>{{/dual_precision_dmg}}
 				</div>
-				<div style="display:table;width:100%;">
+				<div class="sheet-roll-table-inner">
 					<div class="sheet-roll-group2">
 						{{#type}}<div class="sheet-roll-row"><div class="sheet-roll-cell">**<span data-i18n="type">Type</span>**:</div><div class="sheet-roll-cell">{{type}}</div></div>{{/type}}
 						{{#allprops() font color accessible rounded header_image character_name character_id name_link subtitle attack damage crit_confirm crit_damage description attack2 damage2 crit_confirm2 crit_damage2 attack3 damage3 crit_confirm3 crit_damage3 attack4 damage4 crit_confirm4 crit_damage4 attack5 damage5 crit_confirm5 crit_damage5 attack6 damage6 crit_confirm6 crit_damage6 attack7 damage7 crit_confirm7 crit_damage7 attack8 attack9 damage8 damage9 crit_confirm8 crit_confirm9 crit_damage8 crit_damage9 melee_notes ranged_notes CMB_notes attack_notes type weapon_notes generic_note buff_note condition_note precision_dmg1 precision_dmg1_type precision_dmg2 precision_dmg2_type critical_dmg1 critical_dmg1_type critical_dmg2 critical_dmg2_type precision_dmg21 critical_dmg21 precision_dmg22 critical_dmg22 precision_dmg31 critical_dmg31 precision_dmg32 critical_dmg32 precision_dmg41 critical_dmg41 precision_dmg42 critical_dmg42 precision_dmg51 critical_dmg51 precision_dmg52 critical_dmg52 precision_dmg61 critical_dmg61 precision_dmg62 critical_dmg62 precision_dmg71 critical_dmg71 precision_dmg72 critical_dmg72 precision_dmg81 critical_dmg81 precision_dmg82 critical_dmg82 precision_dmg91 critical_dmg91 precision_dmg92 critical_dmg92 attack1name attack2name attack3name attack4name attack5name attack6name attack7name attack8name attack9name vs vsac vstouch vsff vsfft vscmd vscmb vsother no_attack_roll no_damage dual_precision_dmg dual_precision_dmg_type spelltracking1 spelltracking2 spelltracking3 spelltracking4 spelltracking5 spelltracking6 spelldescription1 spelldescription2 spelldescription3 spelldescription4 spelldescription5 spelldescription6 abilitytracking1 abilitytracking2 abilitytracking3 abilitytracking4 abilitytracking5 abilitytracking6 abilitydescription1 abilitydescription2 abilitydescription3 abilitydescription4 abilitydescription5 abilitydescription6 itemtracking1 itemtracking2 itemtracking3 itemtracking4 itemtracking5 itemtracking6 itemdescription1 itemdescription2 itemdescription3 itemdescription4 itemdescription5 itemdescription6 misctracking1 misctracking2 misctracking3 misctracking4 misctracking5 misctracking6 miscdescription1 miscdescription2 miscdescription3 miscdescription4 miscdescription5 miscdescription6}}
@@ -14466,7 +14466,7 @@
 				<div class="sheet-roll-group">
 					{{#buttons}}<div class="sheet-roll-row sheet-roll-description"><div class="sheet-roll-cell">{{buttons}}</div></div>{{/buttons}}
 				</div>					
-				<div style="display:table;width:100%;">
+				<div class="sheet-roll-table-inner">
 					<div class="sheet-roll-group2">
 						{{#allprops() font spellfail showdefenses showsaves showspecialdefenses buttons ac touch flat_footed cmd fort ref will color accessible rounded header_image character_name character_id name_link subtitle defensive-abilities_notes dr_notes resistances_notes immunities_notes weaknesses_notes sr0_notes armor_notes save_notes cmd_notes defense_notes description generic_note buff_note condition_note }}
 						<div class="sheet-roll-row"><div class="sheet-roll-cell">**{{key}}**:</div><div class="sheet-roll-cell">{{value}}</div></div>
@@ -14577,7 +14577,7 @@
 					{{#source}}<div class="sheet-roll-row sheet-roll-description"><div class="sheet-roll-cell">**<span data-i18n="source">Source</span>** {{source}}{{#casterlevel}} ({{casterlevel}}){{/casterlevel}}</div></div>{{/source}}
 					{{#cust_category}}<div class="sheet-roll-row sheet-roll-description"><div class="sheet-roll-cell">{{cust_category}}</div></div>{{/cust_category}}
 				</div>
-				<div style="display:table;width:100%;">
+				<div class="sheet-roll-table-inner">
 					<div class="sheet-roll-group2">
 						{{#hasfrequency}}{{#frequency}}
 							<div class="sheet-roll-row"><div class="sheet-roll-cell">**<span data-i18n="frequency">Frequency</span>**</div>
@@ -14728,7 +14728,7 @@
 					</span>
 					{{#subtitle}}<span class="sheet-subtitle">{{subtitle}}</span>{{/subtitle}}
 				</div>
-				<div style="display:table;width:100%;">
+				<div class="sheet-roll-table-inner">
 					<div class="sheet-roll-group2">
 						{{#check}}<div class="sheet-roll-row"><div class="sheet-roll-cell">**<span data-i18n="check"></span>:**</div><div class="sheet-roll-cell">{{check}}</div></div>{{/check}}
 						{{#class}}<div class="sheet-roll-row"><div class="sheet-roll-cell">**<span data-i18n="class"></span>:**</div><div class="sheet-roll-cell">{{class}}</div></div>{{/class}}
@@ -14747,7 +14747,7 @@
 					{{#lefttext_5}}<div class="sheet-roll-row"><div class="sheet-roll-cell">{{lefttext_5}}</div></div>{{/lefttext_5}}
 					{{#righttext_5}}<div class="sheet-roll-row"><div class="sheet-roll-cell sheet-right">{{righttext_5}}</div></div>{{/righttext_5}}
 				</div>
-				<div style="display:table;width:100%;">
+				<div class="sheet-roll-table-inner">
 					<div class="sheet-roll-group2">
 						{{#allprops() font color accessible rounded header_image character_name name character_id name_link subtitle check init_notes description untrained class generic_note buff_note condition_note righttext_1 lefttext_1 righttext_2 lefttext_2 righttext_3 lefttext_3 righttext_4 lefttext_4 righttext_5 lefttext_5 righttext_6 lefttext_6 righttext_7 lefttext_7 righttext_8 lefttext_8 righttext_9 lefttext_9 righttext_10 lefttext_10 whisper switch lefttext_0 righttext_0 }}
 						<div class="sheet-roll-row"><div class="sheet-roll-cell">**{{key}}**</div><div class="sheet-roll-cell">{{value}}</div></div>

--- a/src/pathfinder.css
+++ b/src/pathfinder.css
@@ -3366,6 +3366,16 @@ input[type="text"].sheet-skill-conds {
 .sheet-rolltemplate-pf_block img {
     vertical-align: middle;
 }
+.sheet-rolltemplate-pf_generic .sheet-roll-table-inner,
+.sheet-rolltemplate-pf_ability .sheet-roll-table-inner,
+.sheet-rolltemplate-pf_defense .sheet-roll-table-inner,
+.sheet-rolltemplate-pf_attack .sheet-roll-table-inner,
+.sheet-rolltemplate-pf_spell .sheet-roll-table-inner,
+.sheet-rolltemplate-pf_block .sheet-roll-table-inner {
+	display: table;
+	width: 100%;
+	min-width:100%;
+}
 .sheet-rolltemplate-pf_generic .sheet-roll-group,
 .sheet-rolltemplate-pf_ability .sheet-roll-group,
 .sheet-rolltemplate-pf_defense .sheet-roll-group,


### PR DESCRIPTION
fixes a bug which breaks all the links for linked attacks
before recalc was breaking all links to spells, now it breaks links to items too
this fixes it