### PR TITLE
change mythic and psionic ability tables to match the others

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7885,7 +7885,7 @@
 						<div class="sheet-h2-section sheet-section-mythic">	
 							<div class="sheet-h2-section sheet-section-mythic" style="display:inline-block; width:60%;" role="region" data-i18n-aria-label="mythic-information">
 								<div class="sheet-table sheet-wide-numbers" >
-									<span class="sheet-table-name sheet-show-readonly" data-i18n="mythic-information">Mythic Information</span>
+									<span class="sheet-secondary-table-name sheet-show-readonly" data-i18n="mythic-information">Mythic Information</span>
 									<div class="sheet-table-row">
 										<span class="sheet-table-header" style="width:1.5em;">#</span>
 										<span class="sheet-table-header" style="width:50%;" data-i18n-title="mythic-path-title" data-i18n-aria-label="mythic-path-title" title="Mythic Path: archmage, champion, guardian, hierophant, marshal, or trickster" data-i18n="mythic-path">Mythic Path</span>
@@ -7908,7 +7908,7 @@
 							</div>
 							<div class="sheet-h2-section sheet-section-mythic" style="display:inline-block;width:39%;" role="region" data-i18n-aria-label="mythic-information">
 								<div class="sheet-table sheet-wide-numbers" >
-									<span class="sheet-table-name sheet-show-readonly" data-i18n="mythic-power">Mythic Power</span>
+									<span class="sheet-secondary-table-name sheet-show-readonly" data-i18n="mythic-power">Mythic Power</span>
 									<div class="sheet-table-row">
 										<span class="sheet-table-header" data-i18n-title="mythic-power-avail-title" data-i18n-aria-label="mythic-power-avail-title" title="How much mythic power you have available to use" data-i18n="mythic-power-current">Current MP</span>
 										<span class="sheet-table-header">/</span>
@@ -7938,7 +7938,7 @@
 					<input class="sheet-showarrow sheet-h2arrow sheet-section-psionic" type="checkbox" name="attr_psionic-info-show" data-i18n-aria-label="psionic-information" data-i18n-title="showsect-cmd"  value="1" checked />
 					<h2 class="sheet-clickheader sheet-showsect sheet-section-psionic"><label data-i18n-title="showsect-cmd"  data-i18n-aria-label="showsect-cmd" data-i18n="psionic-information">Psionic Information</label></h2>
 					<div class="sheet-h2-section sheet-section-psionic sheet-table sheet-wide-readonly sheet-wide-numbers sheet-psionic">
-						<span class="sheet-table-name sheet-show-readonly" data-i18n="psionic-manifester-level-and-power-points">Psionic Manifester Level and Power Points</span>
+						<span class="sheet-secondary-table-name sheet-show-readonly" data-i18n="psionic-manifester-level-and-power-points">Psionic Manifester Level and Power Points</span>
 						<div class="sheet-table-group-head">
 							<div class="sheet-table-row">
 								<span class="sheet-table-header" data-i18n-title="psionic-manifester-lvls-title" data-i18n-aria-label="psionic-manifester-lvls-title" title="The sum of the levels of psionic classes that have a key ability score selected on the right." data-i18n="manifester-levels">Manifester Levels</span>


### PR DESCRIPTION
Switches the class for the "Mythic Information", "Mythic Power" and "Psionic Manifester Level and Power Points" titles so that they have the same blue background as the other tables in the Abilities tab (when the sheet's background is set to none or graph paper).