### PR TITLE
Rework some buffs formula

### DIFF
--- a/src/PFBuffs.js
+++ b/src/PFBuffs.js
@@ -1359,7 +1359,7 @@ function getCommonBuffEntries(name,v,onByDefault){
 			setter[prefix+'b1-show']=1;
 			setter[prefix+'b1_bonus']='attack';
 			setter[prefix+'b1_bonustype']='luck';
-			setter[prefix+'b1_macro-text']='min(3,1+floor((@{level})/6)+floor((@{level})/9))';
+			setter[prefix+'b1_macro-text']='min(3, max(1, floor(@{level}/3)))';
 			tempint=1;
 			if(calc){
 				if(level<=5){
@@ -1374,7 +1374,7 @@ function getCommonBuffEntries(name,v,onByDefault){
 			setter[prefix+'b2-show']=1;
 			setter[prefix+'b2_bonus']='dmg';
 			setter[prefix+'b2_bonustype']='luck';
-			setter[prefix+'b2_macro-text']='min(3,1+floor((@{level})/6)+floor((@{level})/9))';
+			setter[prefix+'b2_macro-text']='min(3, max(1, floor(@{level}/3)))';
 			setter[prefix+'b2_val']=tempint;
 			break;
 		case 'shieldoffaith':

--- a/src/PFBuffs.js
+++ b/src/PFBuffs.js
@@ -1816,7 +1816,7 @@ function getCommonBuffEntries(name,v,onByDefault){
 			setter[prefix+'b1-show']=1;
 			setter[prefix+'b1_bonus']='armor';
 			setter[prefix+'b1_bonustype']='enhancement';
-			setter[prefix+'b1_macro-text']='min(5,1+floor((@{level})/8)+floor((@{level})/12)+floor((@{level})/20))';
+			setter[prefix+'b1_macro-text']='min(5,floor(@{level}/4))';
 			tempint=1;
 			if(calc){
 				tempint = 1+ Math.floor(level/8);


### PR DESCRIPTION
The definition of the buff [Divine favor](https://aonprd.com/SpellDisplay.aspx?ItemName=Divine%20favor) states that it gives 1 luck bonus each 3 levels, min 1 and max 3. This translates into: 1 to start with, 1 more at 6 and 1 more at 9. The current formula correctly calculates these bonuses, but the `floor((@{level})/6)+floor((@{level})/9)` part of it actually reads "+1 at 6, 9 and 12; +2 at 18".

The new formula, functionally identical to the old one, is more legible. Additionally, the intention is to help those who are learning the macro syntax by looking at pre-coded buffs with good, clear examples.

The fix to `magicvestment` does change the behaviour of the formula for level [1, 3].